### PR TITLE
Add Cloudimage file method for uploaded files

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ source 'https://rubygems.org'
 
 gemspec
 
+gem 'aws-sdk-s3'
 gem 'rake'
 gem 'rspec'
 gem 'rubocop'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -17,6 +17,22 @@ GEM
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
     ast (2.4.1)
+    aws-eventstream (1.1.0)
+    aws-partitions (1.341.0)
+    aws-sdk-core (3.103.0)
+      aws-eventstream (~> 1, >= 1.0.2)
+      aws-partitions (~> 1, >= 1.239.0)
+      aws-sigv4 (~> 1.1)
+      jmespath (~> 1.0)
+    aws-sdk-kms (1.36.0)
+      aws-sdk-core (~> 3, >= 3.99.0)
+      aws-sigv4 (~> 1.1)
+    aws-sdk-s3 (1.74.0)
+      aws-sdk-core (~> 3, >= 3.102.1)
+      aws-sdk-kms (~> 1)
+      aws-sigv4 (~> 1.1)
+    aws-sigv4 (1.2.1)
+      aws-eventstream (~> 1, >= 1.0.2)
     cloudimage (0.3.0)
       addressable (~> 2.7)
     coderay (1.1.3)
@@ -40,6 +56,7 @@ GEM
       retriable (~> 3.0)
     i18n (1.8.3)
       concurrent-ruby (~> 1.0)
+    jmespath (1.4.0)
     method_source (1.0.0)
     minitest (5.14.1)
     multi_json (1.14.1)
@@ -108,6 +125,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  aws-sdk-s3
   github_changelog_generator (~> 1.15.2)
   pry (~> 0.13)
   rake

--- a/README.md
+++ b/README.md
@@ -1,8 +1,18 @@
-# Shrine::Cloudimage
+# Shrine::Plugins::Cloudimage
 
-Welcome to your new gem! In this directory, you'll find the files you need to be able to package up your Ruby library into a gem. Put your Ruby code in the file `lib/shrine/cloudimage`. To experiment with that code, run `bin/console` for an interactive prompt.
+![](https://github.com/janklimo/shrine-cloudimage/workflows/Build/badge.svg)
 
-TODO: Delete this and the text above, and describe your gem
+[Cloudimage](https://www.cloudimage.io) integration for [Shrine](https://shrinerb.com).
+
+Supports Ruby `2.4` and above, `JRuby`, and `TruffleRuby`.
+
+- [Shrine::Plugins::Cloudimage](#shrinepluginscloudimage)
+  - [Installation](#installation)
+  - [Configuration](#configuration)
+  - [Usage](#usage)
+  - [Development](#development)
+  - [Contributing](#contributing)
+  - [License](#license)
 
 ## Installation
 
@@ -20,25 +30,51 @@ Or install it yourself as:
 
     $ gem install shrine-cloudimage
 
+## Configuration
+
+Register the plugin with any valid Cloudimage settings:
+
+```ruby
+Shrine.plugin :cloudimage, client: {
+  token: 'token', salt: 'salt', sign_urls: false, signature_length: 10
+}
+```
+
+Or pass in the client object directly:
+
+```ruby
+require 'cloudimage'
+
+Shrine.plugin :cloudimage, Cloudimage::Client.new(
+  token: 'token', salt: 'salt', sign_urls: false, signature_length: 10
+)
+```
+
+See [`cloudimage`](https://github.com/scaleflex/cloudimage-rb) for a list
+of available options.
+
 ## Usage
 
-TODO: Write usage instructions here
+You can generate a Cloudimage URL for a `Shrine::UploadedFile` object by
+calling `#cloudimage_url`:
+
+```ruby
+photo.image.cloudimage_url(w: 300, h: 300, blur: 5)
+# => "https://token.cloudimg.io/v7/https://my-bucket.s3.us-east-1.amazonaws.com/assets/image.jpg?blur=5&h=300&w=300"
+```
 
 ## Development
 
-After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
-
-To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and tags, and push the `.gem` file to [rubygems.org](https://rubygems.org).
+After checking out the repo, run `bundle install` to install dependencies.
+Then, run `bundle exec rake` to run the tests.
 
 ## Contributing
 
-Bug reports and pull requests are welcome on GitHub at https://github.com/[USERNAME]/shrine-cloudimage. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [code of conduct](https://github.com/[USERNAME]/shrine-cloudimage/blob/master/CODE_OF_CONDUCT.md).
-
+Bug reports and pull requests are welcome! This project is intended
+to be a safe, welcoming space for collaboration, and contributors
+are expected to adhere to the
+[code of conduct](https://github.com/scaleflex/cloudimage-rb/blob/master/CODE_OF_CONDUCT.md).
 
 ## License
 
-The gem is available as open source under the terms of the [MIT License](https://opensource.org/licenses/MIT).
-
-## Code of Conduct
-
-Everyone interacting in the Shrine::Cloudimage project's codebases, issue trackers, chat rooms and mailing lists is expected to follow the [code of conduct](https://github.com/[USERNAME]/shrine-cloudimage/blob/master/CODE_OF_CONDUCT.md).
+[MIT](https://opensource.org/licenses/MIT)

--- a/lib/shrine/plugins/cloudimage.rb
+++ b/lib/shrine/plugins/cloudimage.rb
@@ -10,7 +10,7 @@ class Shrine
           opts[:client] = ::Cloudimage::Client.new(**opts[:client])
         end
 
-        uploader.opts[:cloudimage] ||= { purge: false }
+        uploader.opts[:cloudimage] ||= {}
         uploader.opts[:cloudimage].merge!(**opts)
 
         return if uploader.cloudimage_client
@@ -26,7 +26,13 @@ class Shrine
 
       module FileMethods
         def cloudimage_url(**options)
-          cloudimage_client.path(cloudimage_id).to_url(**options)
+          cloudimage_client.path(url).to_url(**options)
+        end
+
+        private
+
+        def cloudimage_client
+          shrine_class.cloudimage_client
         end
       end
     end

--- a/spec/shrine/plugins/cloudimage_spec.rb
+++ b/spec/shrine/plugins/cloudimage_spec.rb
@@ -1,12 +1,17 @@
 # frozen_string_literal: true
 
 require 'shrine/plugins/cloudimage'
-require 'shrine/storage/memory'
+require 'shrine/storage/s3'
 
 describe Shrine::Plugins::Cloudimage do
   before do
     @shrine = Class.new(Shrine)
-    @shrine.storages[:memory] = Shrine::Storage::Memory.new
+    bucket = 'my-bucket'
+    @storage = Shrine::Storage::S3.new(
+      bucket: bucket, stub_responses: true, public: true,
+    )
+    @shrine.storages[:s3] = @storage
+    @s3_site = "https://#{bucket}.s3.us-stubbed-1.amazonaws.com"
   end
 
   describe '.configure' do
@@ -30,6 +35,37 @@ describe Shrine::Plugins::Cloudimage do
     it 'fails on missing :client option' do
       expect { @shrine.plugin :cloudimage }
         .to raise_error Shrine::Error, /:client is required/
+    end
+  end
+
+  describe '#cloudimage_url' do
+    before do
+      @shrine.plugin :cloudimage, client: { token: 'token' }
+      @file =
+        @shrine.upload(StringIO.new('file'), :s3, location: 'assets/image.jpg')
+    end
+
+    it 'returns Cloudimage URL' do
+      expect(@file.cloudimage_url)
+        .to eq "https://token.cloudimg.io/v7/#{@s3_site}/assets/image.jpg"
+    end
+
+    it 'accepts transformation options' do
+      expected = "https://token.cloudimg.io/v7/#{@s3_site}" \
+        '/assets/image.jpg?h=200&w=100'
+      expect(@file.cloudimage_url(w: 100, h: 200)).to eq expected
+    end
+
+    it 'accepts security options' do
+      @shrine.plugin :cloudimage, client: {
+        token: 'token', salt: 'salt', sign_urls: false, signature_length: 10
+      }
+      expected = "https://token.cloudimg.io/v7/#{@s3_site}/assets/image.jpg?" \
+        'ci_eqs=Ymx1cj0yMCZoPTMwMCZ3PTMwMA&ci_seal=a926d4eab9'
+      result = @file.cloudimage_url(
+        blur: 20, w: 300, h: 300, seal_params: %i[w h blur],
+      )
+      expect(result).to eq expected
     end
   end
 end


### PR DESCRIPTION
We start off with passing in the whole URL to `Cloudimage::URI`. The output might be verbose at first:

```ruby
photo.image.cloudimage_url(w: 300, h: 300, blur: 5)
# => "https://token.cloudimg.io/v7/https://my-bucket.s3.us-east-1.amazonaws.com/assets/image.jpg?blur=5&h=300&w=300"
```

but becomes terser when `cloudimage` adds support for aliases, so the above becomes:

```ruby
# aliasing "https://my-bucket.s3.us-east-1.amazonaws.com/assets" to "_alias_"
"https://token.cloudimg.io/v7/_alias_/image.jpg?blur=5&h=300&w=300"

# or the following when origin prefix is configured
"https://token.cloudimg.io/v7/image.jpg?blur=5&h=300&w=300"
```

Closes #1 